### PR TITLE
take "forbidden words" into account when performing search

### DIFF
--- a/classes/orm/behaviour/searchable.php
+++ b/classes/orm/behaviour/searchable.php
@@ -258,6 +258,13 @@ class Orm_Behaviour_Searchable extends \Nos\Orm_Behaviour
                             $where[$k] = array();
                             $i = 1;
                             foreach($keywords_fields as $fields => $keywords) {
+                                // remove forbidden keywords
+                                if (!empty(static::$_jaypssearch_config['forbidden_words'])) {
+                                    $forbidden_words = static::$_jaypssearch_config['forbidden_words'];
+                                    $keywords = array_filter($keywords, function ($a) use ($forbidden_words) {
+                                        return !in_array($a, $forbidden_words);
+                                    });
+                                }
                                 foreach ($keywords as $keyword) {
                                     $keyword = str_replace('%', '', $keyword);
                                     if (mb_strpos($keyword, '*') !== false) {


### PR DESCRIPTION
This follows the previous PR : when words are excluded from index, it is not relevant to perform search on them. Even worse, this would lead to no result, which is not what's expected.

This PR has been tested with a classic usage of the app, i.e. with some code like this :

```
Model_Item::query(array(
  'where' => array(
    array('keywords' => $keywords)
  )
)-> ... ->get();
```
