### PR TITLE
Bugfix: array_unique on a mixed type array

### DIFF
--- a/classes/orm/behaviour/searchable.php
+++ b/classes/orm/behaviour/searchable.php
@@ -352,7 +352,7 @@ class Orm_Behaviour_Searchable extends \Nos\Orm_Behaviour
     {
         if (array_key_exists('where', $options)) {
             $where = $options['where'];
-            $nb_relations_ini = isset($options['related']) && is_array($options['related']) ? count(array_unique($options['related'])) : 0;
+            $nb_relations_ini = isset($options['related']) && is_array($options['related']) ? count(array_unique($options['related'], SORT_REGULAR)) : 0;
             $group_by = !(isset($options['jayps_no_group_by']) && $options['jayps_no_group_by']);
 
             $keywords = array();


### PR DESCRIPTION
A small bug which happen when we use arrays in the "related" option of the query builder.